### PR TITLE
Fix slice out of bound

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312 h1:UsFdQ3ZmlzS0Bq
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/parser.go
+++ b/parser.go
@@ -2,11 +2,12 @@ package ptn
 
 import (
 	"encoding/json"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // TorrentInfo is the resulting structure returned by Parse
@@ -107,6 +108,10 @@ func Parse(filename string) (*TorrentInfo, error) {
 		} else if index < endIndex {
 			endIndex = index
 			//fmt.Printf("    endIndex moved to %d [%q]\n", endIndex, filename[startIndex:endIndex])
+		}
+		if startIndex > endIndex {
+			endIndex = len(filename)
+			continue
 		}
 		setField(tor, pattern.name, matches[matchIdx][1], matches[matchIdx][2])
 	}

--- a/testdata.json
+++ b/testdata.json
@@ -1031,5 +1031,20 @@
       "group": "DIMENSION",
       "ismovie": false
     }
+  },
+  {
+    "fname": "[04x01] The Noose",
+    "wanted": {
+      "title": "The Noose",
+      "season": 4,
+      "episode": 1,
+      "country": "",
+      "resolution": "",
+      "quality": "",
+      "codec": "",
+      "group": "",
+      "website": "",
+      "ismovie": false
+    }
   }
 ]


### PR DESCRIPTION
I found an issue in the pattern matching logic when the regex identifies season and episode pattern within the website pattern leading to a slice out of bound err because `endIndex` is lower than `startingIndex`, made a simple fix by moving the `endIndex` to the very last index so it won't complain.